### PR TITLE
Upgrade Coco core RC integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Guidance for coding agents working in `coco-cashu-plugin-npc`.
 
 ## Project Snapshot
 
-- TypeScript library for integrating NPubCash with `coco-cashu-core`.
+- TypeScript library for integrating NPubCash with `@cashu/coco-core`.
 - Runtime/tooling is Bun-based; builds use `tsdown` and types use `tsc`.
 - Main source lives in `src/`; tests live in `tests/`.
 - Public exports are defined in `src/index.ts`.
@@ -29,7 +29,7 @@ Guidance for coding agents working in `coco-cashu-plugin-npc`.
 - `src/PluginApi.ts`: host-facing API wrapper around payment and NPC clients.
 - `src/sync/sinceStore.ts`: persistence abstractions and default store implementations.
 - `src/types.ts`: shared types, validation helpers, logger helpers, constants.
-- `src/index.ts`: package barrel exports and `coco-cashu-core` module augmentation.
+- `src/index.ts`: package barrel exports and `@cashu/coco-core` module augmentation.
 - `tests/*.test.ts`: Bun tests for exports, sync behavior, stores, and plugin lifecycle.
 
 ## Install And Setup
@@ -145,7 +145,7 @@ Guidance for coding agents working in `coco-cashu-plugin-npc`.
 
 - Do not hand-edit `dist/`; regenerate it with `bun run build` if needed.
 - Keep module augmentation in `src/index.ts` aligned with the extension name registered in `NPCPlugin`.
-- Preserve compatibility with `coco-cashu-core` and `npubcash-sdk` peer/runtime expectations.
+- Preserve compatibility with `@cashu/coco-core` and `npubcash-sdk` peer/runtime expectations.
 - Avoid broad refactors unless the task calls for them; this is a small library with tight behavior.
 - Prefer small, explicit changes and keep tests close to the changed behavior.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # coco-cashu-plugin-npc
 
 `coco-cashu-plugin-npc` integrates one or more NPubCash accounts with
-`coco-cashu-core`. It syncs paid quotes from NPC servers, converts them into
-coco mint quotes, and forwards them through the host's `mintOperationService`.
+`@cashu/coco-core`. It syncs paid quotes from NPC servers, imports them as
+coco mint quotes, and redeems them through the host's mint operation service.
 
 - Polls NPC for paid quotes since a per-account persisted timestamp
 - Optionally listens for realtime websocket updates per account
-- Groups quotes by `mintUrl` before forwarding them to coco
+- Groups quotes by `mintUrl` before importing and redeeming them through coco
 - Exposes an account-aware `npc` extension API for account management, username
   management, quote inspection, and manual sync
 
@@ -19,7 +19,7 @@ bun add coco-cashu-plugin-npc
 Install the required peer dependencies in the host app as well:
 
 ```bash
-bun add coco-cashu-core typescript
+bun add @cashu/coco-core typescript
 ```
 
 This package uses `npubcash-sdk` internally for NPC API access and JWT auth.

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "tsdown": "^0.15.1",
       },
       "peerDependencies": {
-        "@cashu/coco-core": "^2.0.0-rc.0",
+        "@cashu/coco-core": "2.0.0-rc.1",
         "typescript": "^5.0.0",
       },
     },
@@ -30,7 +30,7 @@
 
     "@cashu/cashu-ts": ["@cashu/cashu-ts@3.2.2", "", { "dependencies": { "@noble/curves": "^2.0.1", "@noble/hashes": "^2.0.1", "@scure/bip32": "^2.0.1" } }, "sha512-FD3EBYQiDRhZFwCMXuhAGRAb279WpGEWePzRQk58GJSZy16OdcP3hrYmj7L9wWdETy2fQU0wn+bCuw2NAB6szQ=="],
 
-    "@cashu/coco-core": ["@cashu/coco-core@2.0.0-rc.0", "", { "dependencies": { "@cashu/cashu-ts": "4.5", "@noble/curves": "^2.0.1", "@noble/hashes": "^2.0.1", "@scure/bip32": "^2.0.1" }, "peerDependencies": { "typescript": "^5" } }, "sha512-opcfTq7evBGWE6QlTBuLPPWAkyR0wig0cueb6exwfgfb+f7mg2e0+kYJhBlmDbNUB5wPaedLid5cZIYLCbPRXw=="],
+    "@cashu/coco-core": ["@cashu/coco-core@2.0.0-rc.1", "", { "dependencies": { "@cashu/cashu-ts": "4.5", "@noble/curves": "^2.0.1", "@noble/hashes": "^2.0.1", "@scure/bip32": "^2.0.1" }, "peerDependencies": { "typescript": "^5" } }, "sha512-IBWqhvy2j47erhrtQLZQT4MKHMbEt0eQLg6lIljbwhFsCHMPiM8NCrA1jmmlLtrwvItJxFAmyoiSAphn85jZrA=="],
 
     "@emnapi/core": ["@emnapi/core@1.5.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "tsdown": "^0.15.1",
       },
       "peerDependencies": {
-        "coco-cashu-core": "^1.1.2-rc.50",
+        "@cashu/coco-core": "^2.0.0-rc.0",
         "typescript": "^5.0.0",
       },
     },
@@ -29,6 +29,8 @@
     "@babel/types": ["@babel/types@7.28.4", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q=="],
 
     "@cashu/cashu-ts": ["@cashu/cashu-ts@3.2.2", "", { "dependencies": { "@noble/curves": "^2.0.1", "@noble/hashes": "^2.0.1", "@scure/bip32": "^2.0.1" } }, "sha512-FD3EBYQiDRhZFwCMXuhAGRAb279WpGEWePzRQk58GJSZy16OdcP3hrYmj7L9wWdETy2fQU0wn+bCuw2NAB6szQ=="],
+
+    "@cashu/coco-core": ["@cashu/coco-core@2.0.0-rc.0", "", { "dependencies": { "@cashu/cashu-ts": "4.5", "@noble/curves": "^2.0.1", "@noble/hashes": "^2.0.1", "@scure/bip32": "^2.0.1" }, "peerDependencies": { "typescript": "^5" } }, "sha512-opcfTq7evBGWE6QlTBuLPPWAkyR0wig0cueb6exwfgfb+f7mg2e0+kYJhBlmDbNUB5wPaedLid5cZIYLCbPRXw=="],
 
     "@emnapi/core": ["@emnapi/core@1.5.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg=="],
 
@@ -112,8 +114,6 @@
 
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
-    "coco-cashu-core": ["coco-cashu-core@1.1.2-rc.50", "", { "dependencies": { "@cashu/cashu-ts": "^3.5.0", "@noble/curves": "^2.0.1", "@noble/hashes": "^2.0.1", "@scure/bip32": "^2.0.1" }, "peerDependencies": { "typescript": "^5" } }, "sha512-eK5YuwvCWpeCwF/GEkMo90FCyek2mS+smQ51wKjkjTKzpkVVlNln52l2h1Wwce4VMnW6GSeL2IgT8IksM8Umuw=="],
-
     "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
@@ -180,11 +180,11 @@
 
     "undici-types": ["undici-types@7.11.0", "", {}, "sha512-kt1ZriHTi7MU+Z/r9DOdAI3ONdaR3M3csEaRc6ewa4f4dTvX4cQCbJ4NkEn0ohE4hHtq85+PhPSTY+pO/1PwgA=="],
 
+    "@cashu/coco-core/@cashu/cashu-ts": ["@cashu/cashu-ts@4.5.1", "", { "dependencies": { "@noble/curves": "^2.2.0", "@noble/hashes": "^2.2.0", "@scure/base": "^2.2.0", "@scure/bip32": "^2.2.0" } }, "sha512-AGB7wh1SC0iANRSsdwM091eoS1uVhSf/Qf2VM3plw8EzlYjiFkwSa9X0Nh6NpsE1VVeAuPpNInvpznvElp2Q0A=="],
+
     "@scure/bip32/@scure/base": ["@scure/base@2.0.0", "", {}, "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w=="],
 
     "@scure/bip39/@noble/hashes": ["@noble/hashes@1.3.2", "", {}, "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="],
-
-    "coco-cashu-core/@cashu/cashu-ts": ["@cashu/cashu-ts@3.6.1", "", { "dependencies": { "@noble/curves": "^2.0.1", "@noble/hashes": "^2.0.1", "@scure/base": "^2.0.0", "@scure/bip32": "^2.0.1" } }, "sha512-ynncvX5vv/m2Dzp28m1ApxNsmrsw1p6laOdOnvlHVOPK3x4Nz3K/ScV7UjnbuwubTVeIcKP1FXEdycedhhlJbQ=="],
 
     "nostr-tools/@noble/curves": ["@noble/curves@1.2.0", "", { "dependencies": { "@noble/hashes": "1.3.2" } }, "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw=="],
 
@@ -192,7 +192,13 @@
 
     "nostr-tools/@scure/bip32": ["@scure/bip32@1.3.1", "", { "dependencies": { "@noble/curves": "~1.1.0", "@noble/hashes": "~1.3.1", "@scure/base": "~1.1.0" } }, "sha512-osvveYtyzdEVbt3OfwwXFr4P2iVBL5u1Q3q4ONBfDY/UpOuXmOlbgwc1xECEboY8wIays8Yt6onaWMUdUbfl0A=="],
 
-    "coco-cashu-core/@cashu/cashu-ts/@scure/base": ["@scure/base@2.0.0", "", {}, "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w=="],
+    "@cashu/coco-core/@cashu/cashu-ts/@noble/curves": ["@noble/curves@2.2.0", "", { "dependencies": { "@noble/hashes": "2.2.0" } }, "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ=="],
+
+    "@cashu/coco-core/@cashu/cashu-ts/@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
+
+    "@cashu/coco-core/@cashu/cashu-ts/@scure/base": ["@scure/base@2.2.0", "", {}, "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg=="],
+
+    "@cashu/coco-core/@cashu/cashu-ts/@scure/bip32": ["@scure/bip32@2.2.0", "", { "dependencies": { "@noble/curves": "2.2.0", "@noble/hashes": "2.2.0", "@scure/base": "2.2.0" } }, "sha512-zFr7t2F+a9+5tB7QbarF2HQNYrgjCNaoLAupZdKkrFMYMozJf5zqH2WJCQibMzm1qQ0QogrxVGO3qXfQDYMaQg=="],
 
     "nostr-tools/@noble/curves/@noble/hashes": ["@noble/hashes@1.3.2", "", {}, "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="],
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coco-cashu-plugin-npc",
   "version": "2.4.1",
-  "description": "NPubCash plugin for coco-cashu-core - bridges NPubCash server with coco-cashu wallet",
+  "description": "NPubCash plugin for @cashu/coco-core - bridges NPubCash server with coco wallet",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Egge21M/coco-cashu-plugin-npc.git"
@@ -38,7 +38,7 @@
     "npubcash-sdk": "^0.3.2"
   },
   "peerDependencies": {
-    "coco-cashu-core": "^1.1.2-rc.50",
+    "@cashu/coco-core": "^2.0.0-rc.0",
     "typescript": "^5.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "npubcash-sdk": "^0.3.2"
   },
   "peerDependencies": {
-    "@cashu/coco-core": "^2.0.0-rc.0",
+    "@cashu/coco-core": "2.0.0-rc.1",
     "typescript": "^5.0.0"
   },
   "devDependencies": {

--- a/src/PluginApi.ts
+++ b/src/PluginApi.ts
@@ -1,7 +1,10 @@
-import { getEncodedToken, type PaymentRequestService } from "coco-cashu-core";
+import { getEncodedToken } from "@cashu/coco-core";
 import { PaymentRequiredError } from "npubcash-sdk";
 
-import type { NPCAccountRuntime } from "./accounts/NPCAccountRuntime";
+import type {
+  NPCAccountRuntime,
+  NPCPluginContext,
+} from "./accounts/NPCAccountRuntime";
 import type { NPCPlugin } from "./plugins/NPCPlugin";
 import type {
   AddNPCAccountOptions,
@@ -56,11 +59,15 @@ export class NPCPluginApi {
 export class NPCAccountApi {
   readonly id: string;
 
-  private readonly getPrService: () => PaymentRequestService;
+  private readonly getPrService: () => NPCPluginContext["services"][
+    "paymentRequestService"
+  ];
   private readonly runtime: NPCAccountRuntime;
 
   constructor(
-    getPrService: () => PaymentRequestService,
+    getPrService: () => NPCPluginContext["services"][
+      "paymentRequestService"
+    ],
     runtime: NPCAccountRuntime,
   ) {
     this.id = runtime.id;
@@ -92,18 +99,22 @@ export class NPCAccountApi {
       const creq = e.paymentRequest.toEncodedRequest();
       if (attemptPayment) {
         const prService = this.getPrService();
-        const cocoReq = await prService.processPaymentRequest(creq);
-        if (!cocoReq.matchingMints[0]) {
+        const cocoReq = await prService.parse(creq);
+        const mintUrl = cocoReq.payableMints[0];
+        if (!mintUrl) {
           return { success: false, pr: e.paymentRequest };
         }
-        const tx = await prService.preparePaymentRequestTransaction(
-          cocoReq.matchingMints[0],
-          cocoReq,
-        );
-        await prService.handleInbandPaymentRequest(tx, async (token) => {
-          const tokenString = getEncodedToken(token);
-          await this.runtime.client.setUsername(username, tokenString);
-        });
+        const inbandReq = {
+          ...cocoReq,
+          transport: { type: "inband" as const },
+        };
+        const tx = await prService.prepare(inbandReq, { mintUrl });
+        const result = await prService.execute(tx);
+        if (result.type !== "inband") {
+          throw new Error("Expected inband payment request execution result");
+        }
+        const tokenString = getEncodedToken(result.token);
+        await this.runtime.client.setUsername(username, tokenString);
         return {
           success: true,
         };

--- a/src/accounts/NPCAccountRuntime.ts
+++ b/src/accounts/NPCAccountRuntime.ts
@@ -1,5 +1,5 @@
-import { Amount, type MintMethodQuoteSnapshot } from "@cashu/coco-core";
-import type { PluginContext, ServiceKey } from "@cashu/coco-core/plugin";
+import { Amount } from "@cashu/coco-core";
+import type { PluginContext } from "@cashu/coco-core/plugin";
 import { JWTAuthProvider, NPCClient } from "npubcash-sdk";
 
 import type { SinceStore } from "../sync/sinceStore";
@@ -16,37 +16,15 @@ import {
   isValidUrl,
 } from "../types";
 
-const npcPublicRequiredServices = [
+export const npcRequiredServices = [
   "mintOperationService",
   "mintService",
+  "quotes",
   "paymentRequestService",
   "eventBus",
-] as const satisfies readonly ServiceKey[];
+] as const;
 
-export type NPCPluginRequiredServices = typeof npcPublicRequiredServices;
-
-// @cashu/coco-core 2.0.0-rc.0 exposes quote import on manager.quotes, but not
-// in the public plugin ServiceMap. The runtime service exists and is selected
-// by PluginHost, so this keeps the RC migration localized until core exposes a
-// stable plugin service for canonical quote import.
-export const npcRequiredServices = [
-  ...npcPublicRequiredServices,
-  "quoteLifecycle",
-] as unknown as NPCPluginRequiredServices;
-
-interface QuoteLifecycleService {
-  importMintQuote(
-    mintUrl: string,
-    method: "bolt11",
-    quote: MintMethodQuoteSnapshot<"bolt11">,
-  ): Promise<unknown>;
-}
-
-export type NPCPluginContext = PluginContext<NPCPluginRequiredServices> & {
-  services: PluginContext<NPCPluginRequiredServices>["services"] & {
-    quoteLifecycle: QuoteLifecycleService;
-  };
-};
+export type NPCPluginContext = PluginContext<typeof npcRequiredServices>;
 
 export type SyncTrigger = "manual" | "websocket" | "interval";
 
@@ -418,7 +396,7 @@ export class NPCAccountRuntime {
           await this.syncPaidQuotesOnce({
             mintOperationService: ctx.services.mintOperationService,
             mintService: ctx.services.mintService,
-            quoteLifecycle: ctx.services.quoteLifecycle,
+            quoteApi: ctx.services.quotes,
             trigger,
           });
         } while (this.hasPendingUpdate && !this.isShuttingDown);
@@ -443,11 +421,10 @@ export class NPCAccountRuntime {
   private async syncPaidQuotesOnce(options: {
     mintOperationService: NPCPluginContext["services"]["mintOperationService"];
     mintService: NPCPluginContext["services"]["mintService"];
-    quoteLifecycle: NPCPluginContext["services"]["quoteLifecycle"];
+    quoteApi: NPCPluginContext["services"]["quotes"];
     trigger: SyncTrigger;
   }): Promise<void> {
-    const { mintOperationService, mintService, quoteLifecycle, trigger } =
-      options;
+    const { mintOperationService, mintService, quoteApi, trigger } = options;
     const since = await this.sinceStore.get();
 
     this.logger?.debug?.(
@@ -597,11 +574,11 @@ export class NPCAccountRuntime {
           }
 
           try {
-            await quoteLifecycle.importMintQuote(
+            await quoteApi.mint.import({
               mintUrl,
-              "bolt11",
-              transformedQuote,
-            );
+              method: "bolt11",
+              quote: transformedQuote,
+            });
             const operation =
               existing?.state === "init"
                 ? await this.prepareExistingMintOperation(existing.id)

--- a/src/accounts/NPCAccountRuntime.ts
+++ b/src/accounts/NPCAccountRuntime.ts
@@ -510,15 +510,6 @@ export class NPCAccountRuntime {
     const mintResults = await Promise.all(
       Array.from(mintUrlToQuotes.entries()).map(async ([mintUrl, list]) => {
         const results: QuoteSyncResult[] = [];
-        const transformedQuotes = list.map((quote) => ({
-          ...quote,
-          amount: Amount.from(quote.amount),
-          unit: QUOTE_DEFAULTS.UNIT,
-          expiry: quote.expiresAt,
-          state: QUOTE_DEFAULTS.STATE_PAID,
-          quote: quote.quoteId,
-          request: quote.request ?? "",
-        }));
 
         try {
           await mintService.addMintByUrl(mintUrl, { trusted: true });
@@ -542,38 +533,43 @@ export class NPCAccountRuntime {
           return results;
         }
 
-        for (let i = 0; i < transformedQuotes.length; i++) {
-          const transformedQuote = transformedQuotes[i];
-          if (!transformedQuote) {
-            continue;
-          }
+        for (const quote of list) {
+          try {
+            const transformedQuote = {
+              ...quote,
+              amount: Amount.from(quote.amount),
+              unit: QUOTE_DEFAULTS.UNIT,
+              expiry: quote.expiresAt,
+              state: QUOTE_DEFAULTS.STATE_PAID,
+              quote: quote.quoteId,
+              request: quote.request ?? "",
+            };
 
-          const existing = await mintOperationService.getOperationByQuote(
-            mintUrl,
-            "bolt11",
-            transformedQuote.quote,
-          );
-
-          if (existing && existing.state !== "init") {
-            results.push({
+            const existing = await mintOperationService.getOperationByQuote(
               mintUrl,
-              quoteId: transformedQuote.quoteId,
-              paidAt: transformedQuote.paidAt,
-              status: "skipped",
-            });
-            this.logger?.debug?.(
-              formatLogMessage("Skipping already-tracked quote", {
+              "bolt11",
+              transformedQuote.quote,
+            );
+
+            if (existing && existing.state !== "init") {
+              results.push({
                 mintUrl,
                 quoteId: transformedQuote.quoteId,
-                operationId: existing.id,
-                state: existing.state,
-                accountId: this.id,
-              }),
-            );
-            continue;
-          }
+                paidAt: transformedQuote.paidAt,
+                status: "skipped",
+              });
+              this.logger?.debug?.(
+                formatLogMessage("Skipping already-tracked quote", {
+                  mintUrl,
+                  quoteId: transformedQuote.quoteId,
+                  operationId: existing.id,
+                  state: existing.state,
+                  accountId: this.id,
+                }),
+              );
+              continue;
+            }
 
-          try {
             await quoteApi.mint.import({
               mintUrl,
               method: "bolt11",
@@ -600,15 +596,15 @@ export class NPCAccountRuntime {
           } catch (err) {
             results.push({
               mintUrl,
-              quoteId: transformedQuote.quoteId,
-              paidAt: transformedQuote.paidAt,
+              quoteId: quote.quoteId,
+              paidAt: quote.paidAt,
               status: "failed",
             });
             this.logger?.error?.(
               formatLogMessage("Failed to import quote", {
                 err: String(err),
                 mintUrl,
-                quoteId: transformedQuote.quoteId,
+                quoteId: quote.quoteId,
                 accountId: this.id,
               }),
             );

--- a/src/accounts/NPCAccountRuntime.ts
+++ b/src/accounts/NPCAccountRuntime.ts
@@ -1,4 +1,5 @@
-import type { PluginContext } from "coco-cashu-core";
+import { Amount, type MintMethodQuoteSnapshot } from "@cashu/coco-core";
+import type { PluginContext, ServiceKey } from "@cashu/coco-core/plugin";
 import { JWTAuthProvider, NPCClient } from "npubcash-sdk";
 
 import type { SinceStore } from "../sync/sinceStore";
@@ -15,14 +16,37 @@ import {
   isValidUrl,
 } from "../types";
 
-export const npcRequiredServices = [
+const npcPublicRequiredServices = [
   "mintOperationService",
   "mintService",
   "paymentRequestService",
   "eventBus",
-] as const;
+] as const satisfies readonly ServiceKey[];
 
-export type NPCPluginContext = PluginContext<typeof npcRequiredServices>;
+export type NPCPluginRequiredServices = typeof npcPublicRequiredServices;
+
+// @cashu/coco-core 2.0.0-rc.0 exposes quote import on manager.quotes, but not
+// in the public plugin ServiceMap. The runtime service exists and is selected
+// by PluginHost, so this keeps the RC migration localized until core exposes a
+// stable plugin service for canonical quote import.
+export const npcRequiredServices = [
+  ...npcPublicRequiredServices,
+  "quoteLifecycle",
+] as unknown as NPCPluginRequiredServices;
+
+interface QuoteLifecycleService {
+  importMintQuote(
+    mintUrl: string,
+    method: "bolt11",
+    quote: MintMethodQuoteSnapshot<"bolt11">,
+  ): Promise<unknown>;
+}
+
+export type NPCPluginContext = PluginContext<NPCPluginRequiredServices> & {
+  services: PluginContext<NPCPluginRequiredServices>["services"] & {
+    quoteLifecycle: QuoteLifecycleService;
+  };
+};
 
 export type SyncTrigger = "manual" | "websocket" | "interval";
 
@@ -394,6 +418,7 @@ export class NPCAccountRuntime {
           await this.syncPaidQuotesOnce({
             mintOperationService: ctx.services.mintOperationService,
             mintService: ctx.services.mintService,
+            quoteLifecycle: ctx.services.quoteLifecycle,
             trigger,
           });
         } while (this.hasPendingUpdate && !this.isShuttingDown);
@@ -418,9 +443,11 @@ export class NPCAccountRuntime {
   private async syncPaidQuotesOnce(options: {
     mintOperationService: NPCPluginContext["services"]["mintOperationService"];
     mintService: NPCPluginContext["services"]["mintService"];
+    quoteLifecycle: NPCPluginContext["services"]["quoteLifecycle"];
     trigger: SyncTrigger;
   }): Promise<void> {
-    const { mintOperationService, mintService, trigger } = options;
+    const { mintOperationService, mintService, quoteLifecycle, trigger } =
+      options;
     const since = await this.sinceStore.get();
 
     this.logger?.debug?.(
@@ -508,6 +535,7 @@ export class NPCAccountRuntime {
         const results: QuoteSyncResult[] = [];
         const transformedQuotes = list.map((quote) => ({
           ...quote,
+          amount: Amount.from(quote.amount),
           unit: QUOTE_DEFAULTS.UNIT,
           expiry: quote.expiresAt,
           state: QUOTE_DEFAULTS.STATE_PAID,
@@ -545,6 +573,7 @@ export class NPCAccountRuntime {
 
           const existing = await mintOperationService.getOperationByQuote(
             mintUrl,
+            "bolt11",
             transformedQuote.quote,
           );
 
@@ -568,7 +597,23 @@ export class NPCAccountRuntime {
           }
 
           try {
-            await mintOperationService.importQuote(mintUrl, transformedQuote);
+            await quoteLifecycle.importMintQuote(
+              mintUrl,
+              "bolt11",
+              transformedQuote,
+            );
+            const operation =
+              existing?.state === "init"
+                ? await this.prepareExistingMintOperation(existing.id)
+                : await mintOperationService.prepare(
+                    {
+                      mintUrl,
+                      method: "bolt11",
+                      quoteId: transformedQuote.quote,
+                    },
+                    transformedQuote.amount,
+                  );
+            await mintOperationService.execute(operation.id);
             results.push({
               mintUrl,
               quoteId: transformedQuote.quoteId,
@@ -662,5 +707,21 @@ export class NPCAccountRuntime {
         }),
       );
     }
+  }
+
+  private async prepareExistingMintOperation(
+    operationId: string,
+  ): Promise<{ id: string }> {
+    const service = this.ctx?.services.mintOperationService as unknown as {
+      prepareInitOperation?: (operationId: string) => Promise<{ id: string }>;
+    };
+
+    if (typeof service.prepareInitOperation !== "function") {
+      throw new Error(
+        "Mint operation service cannot prepare existing init operations in this @cashu/coco-core RC",
+      );
+    }
+
+    return service.prepareInitOperation(operationId);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ export * from "./PluginApi";
 
 import type { NPCPluginApi } from "./PluginApi";
 
-declare module "coco-cashu-core" {
+declare module "@cashu/coco-core/plugin" {
   interface PluginExtensions {
     npc: NPCPluginApi;
   }

--- a/src/plugins/NPCPlugin.ts
+++ b/src/plugins/NPCPlugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "coco-cashu-core";
+import type { Plugin } from "@cashu/coco-core/plugin";
 
 import {
   NPCAccountRuntime,
@@ -43,7 +43,7 @@ interface AccountEntry {
 }
 
 /**
- * NPubCash plugin for coco-cashu-core.
+ * NPubCash plugin for @cashu/coco-core.
  *
  * The plugin owns host-level registration while account runtimes own NPC
  * clients, signers, timers, websocket subscriptions, and quote sync state.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { Logger } from "coco-cashu-core";
+import type { Logger } from "@cashu/coco-core";
 import type { JWTAuthProvider, PaymentRequiredError } from "npubcash-sdk";
 
 import type { SinceStore } from "./sync/sinceStore";

--- a/tests/PluginApi.test.ts
+++ b/tests/PluginApi.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { PaymentRequiredError } from "npubcash-sdk";
 
 import { NPCPluginApi } from "../src/PluginApi";
 import { NPCPlugin } from "../src/plugins/NPCPlugin";
@@ -12,6 +13,12 @@ import {
 } from "./helpers";
 
 describe("NPCPluginApi", () => {
+  function makePaymentRequiredError(): PaymentRequiredError {
+    return new PaymentRequiredError("payment required", {
+      toEncodedRequest: () => "creq-test",
+    } as unknown as ConstructorParameters<typeof PaymentRequiredError>[1]);
+  }
+
   it("adds an account and returns an account API", async () => {
     const plugin = new NPCPlugin();
     const { ctx } = createMockContext();
@@ -25,6 +32,123 @@ describe("NPCPluginApi", () => {
 
     expect(account.id).toBe("account-1");
     expect(typeof account.sync).toBe("function");
+  });
+
+  it("forces username payment requests through inband execution and submits the token", async () => {
+    const plugin = new NPCPlugin();
+    const { services } = createMockServices();
+    const prepareRequests: unknown[] = [];
+    const submittedTokens: string[] = [];
+
+    services.paymentRequestService = {
+      parse: async () => ({
+        paymentRequest: {},
+        payableMints: ["https://mint.a"],
+        allowedMints: [],
+        unit: "sat",
+        transport: { type: "http", url: "https://merchant.example.com/pr" },
+      }),
+      prepare: async (request: unknown) => {
+        prepareRequests.push(request);
+        return { request, sendOperation: { id: "send-1" } };
+      },
+      execute: async (tx: { request: unknown }) => {
+        expect(tx.request).toMatchObject({ transport: { type: "inband" } });
+        return {
+          type: "inband",
+          token: { mint: "https://mint.a", proofs: [] },
+          operation: { id: "send-1", state: "pending" },
+          request: tx.request,
+        };
+      },
+    };
+
+    const ctx = {
+      services,
+      registerExtension: () => {},
+    };
+
+    plugin.onInit(ctx as unknown as Parameters<typeof plugin.onInit>[0]);
+    const account = await plugin.addAccount({
+      id: "account-1",
+      signer: createMockSigner(),
+      baseUrl: "https://npc.example.com",
+    });
+
+    const runtime = getAccountRuntime(plugin);
+    let calls = 0;
+    (runtime as unknown as { client: unknown }).client = {
+      setUsername: async (_username: string, token?: string) => {
+        calls += 1;
+        if (!token) {
+          throw makePaymentRequiredError();
+        }
+        submittedTokens.push(token);
+      },
+    };
+
+    await expect(account.setUsername("alice", true)).resolves.toEqual({
+      success: true,
+    });
+
+    expect(calls).toBe(2);
+    expect(prepareRequests).toHaveLength(1);
+    expect(prepareRequests[0]).toMatchObject({
+      transport: { type: "inband" },
+    });
+    expect(submittedTokens).toEqual([
+      "cashuBo2Ftbmh0dHBzOi8vbWludC5hYXVjc2F0YXSA",
+    ]);
+  });
+
+  it("does not execute username payment requests when no payable mint exists", async () => {
+    const plugin = new NPCPlugin();
+    const { services } = createMockServices();
+    let prepared = false;
+    let executed = false;
+
+    services.paymentRequestService = {
+      parse: async () => ({
+        paymentRequest: {},
+        payableMints: [],
+        allowedMints: [],
+        unit: "sat",
+        transport: { type: "inband" },
+      }),
+      prepare: async () => {
+        prepared = true;
+        return {};
+      },
+      execute: async () => {
+        executed = true;
+        return {};
+      },
+    };
+
+    const ctx = {
+      services,
+      registerExtension: () => {},
+    };
+
+    plugin.onInit(ctx as unknown as Parameters<typeof plugin.onInit>[0]);
+    const account = await plugin.addAccount({
+      id: "account-1",
+      signer: createMockSigner(),
+      baseUrl: "https://npc.example.com",
+    });
+
+    const runtime = getAccountRuntime(plugin);
+    (runtime as unknown as { client: unknown }).client = {
+      setUsername: async () => {
+        throw makePaymentRequiredError();
+      },
+    };
+
+    const result = await account.setUsername("alice", true);
+
+    expect(result.success).toBe(false);
+    expect(prepared).toBe(false);
+    expect(executed).toBe(false);
   });
 
   it("exposes account management through the registered extension", async () => {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -19,6 +19,8 @@ export function createMockServices() {
   const calls = {
     addMintByUrl: [] as string[],
     importQuote: [] as { url: string; quote: unknown }[],
+    prepareMintOperation: [] as { quoteId: string; amount: unknown }[],
+    executeMintOperation: [] as string[],
   };
   const eventHandlers = new Map<string, Set<(payload?: unknown) => void>>();
   const eventBus = {
@@ -53,7 +55,27 @@ export function createMockServices() {
     },
     mintOperationService: {
       getOperationByQuote: async () => undefined,
-      importQuote: async (url: string, quote: unknown) => {
+      prepare: async (
+        quoteRef: { quoteId: string },
+        amount: unknown,
+      ) => {
+        calls.prepareMintOperation.push({
+          quoteId: quoteRef.quoteId,
+          amount,
+        });
+        return { id: `op-${quoteRef.quoteId}`, state: "pending" };
+      },
+      execute: async (operationId: string) => {
+        calls.executeMintOperation.push(operationId);
+        return { id: operationId, state: "finalized" };
+      },
+    },
+    quoteLifecycle: {
+      importMintQuote: async (
+        url: string,
+        _method: string,
+        quote: unknown,
+      ) => {
         calls.importQuote.push({ url, quote });
       },
     },

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -70,13 +70,14 @@ export function createMockServices() {
         return { id: operationId, state: "finalized" };
       },
     },
-    quoteLifecycle: {
-      importMintQuote: async (
-        url: string,
-        _method: string,
-        quote: unknown,
-      ) => {
-        calls.importQuote.push({ url, quote });
+    quotes: {
+      mint: {
+        import: async (input: { mintUrl: string; quote: unknown }) => {
+          calls.importQuote.push({
+            url: input.mintUrl,
+            quote: input.quote,
+          });
+        },
       },
     },
     paymentRequestService: {},

--- a/tests/syncPaidQuotes.test.ts
+++ b/tests/syncPaidQuotes.test.ts
@@ -42,16 +42,15 @@ function createContext(calls: {
           state: "pending",
         }),
       },
-      quoteLifecycle: {
-        importMintQuote: async (
-          url: string,
-          _method: string,
-          quote: unknown,
-        ) => {
-          calls.importAttempt?.push(
-            String((quote as { quoteId?: string }).quoteId),
-          );
-          calls.importQuote?.push({ url, quote });
+      quotes: {
+        mint: {
+          import: async (input: { mintUrl: string; quote: unknown }) => {
+            const { mintUrl, quote } = input;
+            calls.importAttempt?.push(
+              String((quote as { quoteId?: string }).quoteId),
+            );
+            calls.importQuote?.push({ url: mintUrl, quote });
+          },
         },
       },
       paymentRequestService: {},
@@ -254,25 +253,24 @@ describe("NPC account sync mapping", () => {
             state: "finalized",
           }),
         },
-        quoteLifecycle: {
-          importMintQuote: async (
-            url: string,
-            _method: string,
-            quote: unknown,
-          ) => {
-            const record = quote as Record<string, unknown>;
-            calls.importAttempt.push(String(record.quoteId));
-            if (record.quoteId === "q2") {
-              throw new Error("boom");
-            }
-            trackedQuotes.set(String(record.quoteId), {
-              id: `op-${String(record.quoteId)}`,
-              state: "finalized",
-            });
-            calls.importQuote.push({
-              url,
-              quote: record,
-            });
+        quotes: {
+          mint: {
+            import: async (input: { mintUrl: string; quote: unknown }) => {
+              const { mintUrl, quote } = input;
+              const record = quote as Record<string, unknown>;
+              calls.importAttempt.push(String(record.quoteId));
+              if (record.quoteId === "q2") {
+                throw new Error("boom");
+              }
+              trackedQuotes.set(String(record.quoteId), {
+                id: `op-${String(record.quoteId)}`,
+                state: "finalized",
+              });
+              calls.importQuote.push({
+                url: mintUrl,
+                quote: record,
+              });
+            },
           },
         },
         paymentRequestService: {},
@@ -402,14 +400,13 @@ describe("NPC account sync mapping", () => {
             state: "pending",
           }),
         },
-        quoteLifecycle: {
-          importMintQuote: async (
-            _url: string,
-            _method: string,
-            quote: unknown,
-          ) => {
-            const record = quote as Record<string, unknown>;
-            calls.importAttempt.push(String(record.quoteId));
+        quotes: {
+          mint: {
+            import: async (input: { quote: unknown }) => {
+              const { quote } = input;
+              const record = quote as Record<string, unknown>;
+              calls.importAttempt.push(String(record.quoteId));
+            },
           },
         },
         paymentRequestService: {},

--- a/tests/syncPaidQuotes.test.ts
+++ b/tests/syncPaidQuotes.test.ts
@@ -21,12 +21,36 @@ function createContext(calls: {
         },
       },
       mintOperationService: {
-        getOperationByQuote: async (_url: string, quoteId: string) => {
+        getOperationByQuote: async (
+          _url: string,
+          _method: string,
+          quoteId: string,
+        ) => {
           calls.lookupQuote?.push(quoteId);
           return undefined;
         },
-        importQuote: async (url: string, quote: unknown) => {
-          calls.importAttempt?.push(String((quote as { quoteId?: string }).quoteId));
+        prepare: async (quoteRef: { quoteId: string }) => ({
+          id: `op-${quoteRef.quoteId}`,
+          state: "pending",
+        }),
+        execute: async (operationId: string) => ({
+          id: operationId,
+          state: "finalized",
+        }),
+        prepareInitOperation: async (operationId: string) => ({
+          id: operationId,
+          state: "pending",
+        }),
+      },
+      quoteLifecycle: {
+        importMintQuote: async (
+          url: string,
+          _method: string,
+          quote: unknown,
+        ) => {
+          calls.importAttempt?.push(
+            String((quote as { quoteId?: string }).quoteId),
+          );
           calls.importQuote?.push({ url, quote });
         },
       },
@@ -213,11 +237,29 @@ describe("NPC account sync mapping", () => {
           addMintByUrl: async () => {},
         },
         mintOperationService: {
-          getOperationByQuote: async (_url: string, quoteId: string) => {
+          getOperationByQuote: async (
+            _url: string,
+            _method: string,
+            quoteId: string,
+          ) => {
             calls.lookupQuote.push(quoteId);
             return trackedQuotes.get(quoteId);
           },
-          importQuote: async (url: string, quote: unknown) => {
+          prepare: async (quoteRef: { quoteId: string }) => ({
+            id: `op-${quoteRef.quoteId}`,
+            state: "pending",
+          }),
+          execute: async (operationId: string) => ({
+            id: operationId,
+            state: "finalized",
+          }),
+        },
+        quoteLifecycle: {
+          importMintQuote: async (
+            url: string,
+            _method: string,
+            quote: unknown,
+          ) => {
             const record = quote as Record<string, unknown>;
             calls.importAttempt.push(String(record.quoteId));
             if (record.quoteId === "q2") {
@@ -341,9 +383,31 @@ describe("NPC account sync mapping", () => {
           addMintByUrl: async () => {},
         },
         mintOperationService: {
-          getOperationByQuote: async (_url: string, quoteId: string) =>
+          getOperationByQuote: async (
+            _url: string,
+            _method: string,
+            quoteId: string,
+          ) =>
             existingByQuote.get(quoteId),
-          importQuote: async (_url: string, quote: unknown) => {
+          prepare: async (quoteRef: { quoteId: string }) => ({
+            id: `op-${quoteRef.quoteId}`,
+            state: "pending",
+          }),
+          execute: async (operationId: string) => ({
+            id: operationId,
+            state: "finalized",
+          }),
+          prepareInitOperation: async (operationId: string) => ({
+            id: operationId,
+            state: "pending",
+          }),
+        },
+        quoteLifecycle: {
+          importMintQuote: async (
+            _url: string,
+            _method: string,
+            quote: unknown,
+          ) => {
             const record = quote as Record<string, unknown>;
             calls.importAttempt.push(String(record.quoteId));
           },

--- a/tests/syncPaidQuotes.test.ts
+++ b/tests/syncPaidQuotes.test.ts
@@ -194,6 +194,82 @@ describe("NPC account sync mapping", () => {
     expect(warnings.length).toBe(2);
   });
 
+  it("fails quotes with malformed amounts without aborting the mint batch", async () => {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+    const calls = {
+      importQuote: [] as { url: string; quote: unknown }[],
+      lookupQuote: [] as string[],
+      setSince: [] as number[],
+    };
+
+    const sinceStore = {
+      get: async () => 0,
+      set: async (since: number) => {
+        calls.setSince.push(since);
+      },
+    };
+
+    const plugin = new NPCPlugin({
+      logger: {
+        warn: (data: unknown) => {
+          warnings.push(String(data));
+        },
+        error: (data: unknown) => {
+          errors.push(String(data));
+        },
+        info: () => {},
+        debug: () => {},
+      },
+    });
+    const ctx = createContext(calls);
+    plugin.onInit(ctx as Parameters<typeof plugin.onInit>[0]);
+    const account = await plugin.addAccount({
+      id: "account-1",
+      signer: createMockSigner(),
+      baseUrl: "https://npc.example.com",
+      sinceStore,
+    });
+    plugin.onReady();
+
+    const runtime = getAccountRuntime(plugin);
+    (runtime as unknown as { client: unknown }).client = {
+      getQuotesSince: async () => [
+        {
+          mintUrl: "https://mint.a",
+          quoteId: "q1",
+          paidAt: 100,
+          expiresAt: 200,
+          amount: 50,
+        },
+        {
+          mintUrl: "https://mint.a",
+          quoteId: "q2",
+          paidAt: 150,
+          expiresAt: 250,
+        },
+      ],
+    };
+
+    await account.sync();
+
+    const importedQuoteIds = calls.importQuote.map((entry) => {
+      const quote = entry.quote as Record<string, unknown>;
+      return quote.quoteId;
+    });
+
+    expect(importedQuoteIds).toEqual(["q1"]);
+    expect(calls.lookupQuote).toEqual(["q1"]);
+    expect(calls.setSince).toEqual([100]);
+    expect(
+      warnings.some((message) =>
+        message.includes("Sync completed with quote failures"),
+      ),
+    ).toBe(true);
+    expect(errors.some((message) => message.includes("Failed to import quote")))
+      .toBe(true);
+  });
+
   it("advances since only to the safe watermark and skips already-tracked retries", async () => {
     const warnings: string[] = [];
     const errors: string[] = [];


### PR DESCRIPTION
## Summary

- Replace the legacy `coco-cashu-core` peer with `@cashu/coco-core@^2.0.0-rc.0` and update imports/module augmentation.
- Migrate NPC paid quote sync to import canonical BOLT11 quotes, prepare mint operations, and execute them through the RC APIs.
- Force username payment-required flows through Coco's inband payment request execution path, then submit the resulting token to NPC.
- Update docs and tests for the new RC integration.

## Validation

- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun test`
- `bun run build`