### PR TITLE
Tighten NPC trust flow and sync handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ interface NPCPluginOptions {
   useWebsocket?: boolean;
   sinceStore?: SinceStore;
   logger?: Logger;
+  quoteMintPolicy?: NPCQuoteMintPolicy;
 }
 ```
 
@@ -61,6 +62,20 @@ interface NPCPluginOptions {
 - `useWebsocket`: subscribe to realtime quote updates from NPC
 - `sinceStore`: persistence for the last processed `paidAt` timestamp; defaults to in-memory storage
 - `logger`: optional logger used by the plugin and derived child loggers
+- `quoteMintPolicy`: controls which quote mints can be imported; defaults to `{ mode: "trusted-only" }`
+
+Quote mint policy options:
+
+```ts
+type NPCQuoteMintPolicy =
+  | { mode: "trusted-only" }
+  | { mode: "allow-list"; mintUrls: readonly string[] }
+  | { mode: "auto-trust" };
+```
+
+- `trusted-only`: import only quotes whose mint is already trusted by the host wallet
+- `allow-list`: import only listed mint URLs and cache them as untrusted when needed
+- `auto-trust`: legacy opt-in behavior that adds quote mints as trusted before import
 
 ## Extension API
 
@@ -71,7 +86,11 @@ const npc = core.extensions.npc;
 
 await npc.getInfo();
 await npc.getQuotesSince(0);
-await npc.sync();
+const report = await npc.sync();
+console.log(report.blockedQuotes);
+
+await npc.setMintUrl("https://mint.example.com");
+await npc.setLockQuotes(true);
 
 const result = await npc.setUsername("alice", true);
 if (!result.success) {
@@ -84,11 +103,16 @@ Available methods:
 - `getInfo()`: fetch authenticated NPC account metadata
 - `setUsername(username, attemptPayment?)`: set the NPC username and optionally handle the payment-required flow through coco
 - `getQuotesSince(sinceUnix)`: inspect raw NPC quotes without importing them into coco
-- `sync()`: manually trigger the plugin's quote sync pipeline
+- `sync()`: manually trigger the plugin's quote sync pipeline and return an `NPCSyncReport`
+- `getStatus()`: inspect lifecycle state and currently blocked quote mints
+- `getLastSyncReport()`: return the most recent sync report without starting a new sync
+- `setMintUrl(mintUrl)`: update the NPC account's server-side mint URL
+- `setLockQuotes(lock)`: enable or disable NPC server-side quote locking
 
 `sync()` uses the same guardrails as scheduled syncing: it waits for `onReady()`,
 batches overlapping calls, respects shutdown, validates quotes, groups by mint,
-and advances `since` only to the highest safe watermark after processing.
+applies quote mint policy, and advances `since` only to the highest safe
+watermark after processing.
 
 ## Sync Behavior
 
@@ -98,8 +122,9 @@ Each sync cycle:
 2. Fetches paid quotes from NPC with `getQuotesSince(since)`
 3. Filters out already-processed timestamps, invalid quotes, and invalid mint URLs
 4. Groups valid quotes by `mintUrl`
-5. Adds each mint as trusted and forwards transformed quotes to coco
-6. Advances `since` to the highest contiguous `paidAt` watermark with no unresolved failures
+5. Applies `quoteMintPolicy` before forwarding transformed quotes to coco
+6. Reports disallowed quote mints as `blockedQuotes`
+7. Advances `since` to the highest contiguous `paidAt` watermark with no unresolved failures or blocked quotes
 
 Important behaviors:
 
@@ -107,7 +132,8 @@ Important behaviors:
 - interval polling rearms after the current sync finishes
 - websocket failures are cleaned up before reconnect attempts are scheduled
 - already-tracked quotes are skipped safely on retry
-- `since` only advances to a safe watermark before the first unresolved failure
+- `since` only advances to a safe watermark before the first unresolved failure or blocked quote
+- the plugin does not trust new quote mints unless `quoteMintPolicy` is explicitly set to `auto-trust`
 
 ## Public Exports
 

--- a/src/PluginApi.ts
+++ b/src/PluginApi.ts
@@ -1,5 +1,9 @@
 import { getEncodedToken, type PaymentRequestService } from "coco-cashu-core";
 import { PaymentRequiredError, type NPCClient } from "npubcash-sdk";
+import type {
+  NPCPluginStatus,
+  NPCSyncReport,
+} from "./plugins/NPCPlugin";
 
 export type SetUsernameResult =
   | { success: true }
@@ -11,7 +15,9 @@ export type SetUsernameResult =
 export class PluginApi {
   private prService: PaymentRequestService;
   private client: NPCClient;
-  private syncQuotes: () => Promise<void>;
+  private syncQuotes: () => Promise<NPCSyncReport>;
+  private getPluginStatus: () => NPCPluginStatus;
+  private getPluginSyncReport: () => NPCSyncReport;
 
   /**
    * Creates a plugin API wrapper around payment and NPC clients.
@@ -21,11 +27,15 @@ export class PluginApi {
   constructor(
     prService: PaymentRequestService,
     client: NPCClient,
-    syncQuotes: () => Promise<void>,
+    syncQuotes: () => Promise<NPCSyncReport>,
+    getPluginStatus: () => NPCPluginStatus,
+    getPluginSyncReport: () => NPCSyncReport,
   ) {
     this.prService = prService;
     this.client = client;
     this.syncQuotes = syncQuotes;
+    this.getPluginStatus = getPluginStatus;
+    this.getPluginSyncReport = getPluginSyncReport;
   }
 
   /**
@@ -89,7 +99,39 @@ export class PluginApi {
   /**
    * Triggers a plugin sync cycle through the host integration.
    */
-  async sync(): Promise<void> {
-    await this.syncQuotes();
+  async sync(): Promise<NPCSyncReport> {
+    return this.syncQuotes();
+  }
+
+  /**
+   * Returns plugin lifecycle and sync policy status.
+   */
+  getStatus(): NPCPluginStatus {
+    return this.getPluginStatus();
+  }
+
+  /**
+   * Returns the report from the most recent plugin sync cycle.
+   */
+  getLastSyncReport(): NPCSyncReport {
+    return this.getPluginSyncReport();
+  }
+
+  /**
+   * Updates the NPC account's preferred server-side mint URL.
+   */
+  async setMintUrl(
+    mintUrl: string,
+  ): Promise<Awaited<ReturnType<NPCClient["settings"]["setMintUrl"]>>> {
+    return this.client.settings.setMintUrl(mintUrl);
+  }
+
+  /**
+   * Enables or disables server-side quote locking for the NPC account.
+   */
+  async setLockQuotes(
+    lock: boolean,
+  ): Promise<Awaited<ReturnType<NPCClient["settings"]["setLock"]>>> {
+    return this.client.settings.setLock(lock);
   }
 }

--- a/src/plugins/NPCPlugin.ts
+++ b/src/plugins/NPCPlugin.ts
@@ -23,13 +23,54 @@ const requiredServices = [
 /** Trigger types for sync operations */
 type SyncTrigger = "manual" | "websocket" | "interval";
 
-type QuoteSyncStatus = "imported" | "skipped" | "failed";
+type QuoteSyncStatus = "imported" | "skipped" | "failed" | "blocked";
+
+/**
+ * Policy controlling which quote mints the plugin may import into coco.
+ */
+export type NPCQuoteMintPolicy =
+  | { mode: "trusted-only" }
+  | { mode: "allow-list"; mintUrls: readonly string[] }
+  | { mode: "auto-trust" };
+
+/**
+ * A paid NPC quote that was not imported because host mint policy blocked it.
+ */
+export interface NPCBlockedQuote {
+  mintUrl: string;
+  quoteId: string;
+  paidAt: number;
+}
+
+/**
+ * A paid NPC quote that failed during import.
+ */
+export interface NPCFailedQuote {
+  mintUrl: string;
+  quoteId: string;
+  paidAt: number;
+  error: string;
+}
+
+/**
+ * Report from the most recent sync cycle.
+ */
+export interface NPCSyncReport {
+  since: number;
+  newSince: number;
+  importedCount: number;
+  skippedCount: number;
+  failedCount: number;
+  blockedQuotes: NPCBlockedQuote[];
+  failedQuotes: NPCFailedQuote[];
+}
 
 interface QuoteSyncResult {
   mintUrl: string;
   quoteId: string;
   paidAt: number;
   status: QuoteSyncStatus;
+  error?: string;
 }
 
 /** Default WebSocket reconnection settings */
@@ -71,6 +112,12 @@ export interface NPCPluginOptions {
    * a child logger with module context.
    */
   logger?: Logger;
+
+  /**
+   * Policy controlling which quote mints the plugin may import.
+   * Defaults to requiring a mint that the host wallet already trusts.
+   */
+  quoteMintPolicy?: NPCQuoteMintPolicy;
 }
 
 /**
@@ -85,6 +132,8 @@ export interface NPCPluginStatus {
   isSyncing: boolean;
   /** Whether WebSocket is connected */
   isWebSocketConnected: boolean;
+  /** Paid quotes currently blocked by quote mint policy */
+  blockedQuotes: NPCBlockedQuote[];
 }
 
 /**
@@ -102,10 +151,11 @@ export class NPCPlugin implements Plugin<typeof requiredServices> {
   private readonly logger?: StructuredLogger;
   private readonly intervalMs?: number;
   private readonly useWebsocket: boolean;
+  private readonly quoteMintPolicy: NPCQuoteMintPolicy;
 
   private isRunning = false;
   private hasPendingUpdate = false;
-  private runPromise?: Promise<void>;
+  private runPromise?: Promise<NPCSyncReport>;
   private unsubscribe?: () => void;
   private intervalTimer?: ReturnType<typeof setTimeout>;
   private isReady = false;
@@ -115,6 +165,15 @@ export class NPCPlugin implements Plugin<typeof requiredServices> {
   private ctx?: PluginContext<typeof requiredServices>;
   private isShuttingDown = false;
   private readyWaiters: Array<() => void> = [];
+  private lastSyncReport: NPCSyncReport = {
+    since: 0,
+    newSince: 0,
+    importedCount: 0,
+    skippedCount: 0,
+    failedCount: 0,
+    blockedQuotes: [],
+    failedQuotes: [],
+  };
 
   /**
    * Creates a new NPCPlugin instance.
@@ -129,7 +188,8 @@ export class NPCPlugin implements Plugin<typeof requiredServices> {
       throw new Error(`Invalid baseUrl: ${baseUrl}`);
     }
 
-    const { syncIntervalMs, useWebsocket, sinceStore, logger } = options ?? {};
+    const { syncIntervalMs, useWebsocket, sinceStore, logger, quoteMintPolicy } =
+      options ?? {};
 
     this.sinceStore = sinceStore ?? new MemorySinceStore(0);
     this.logger = createChildLogger(logger as StructuredLogger, {
@@ -137,6 +197,7 @@ export class NPCPlugin implements Plugin<typeof requiredServices> {
     });
     this.intervalMs = syncIntervalMs;
     this.useWebsocket = !!useWebsocket;
+    this.quoteMintPolicy = quoteMintPolicy ?? { mode: "trusted-only" };
 
     const npcLogger = createChildLogger(logger as StructuredLogger, {
       module: "npc-client",
@@ -157,6 +218,18 @@ export class NPCPlugin implements Plugin<typeof requiredServices> {
       isReady: this.isReady,
       isSyncing: this.isRunning,
       isWebSocketConnected: this.isWebSocketConnected,
+      blockedQuotes: [...this.lastSyncReport.blockedQuotes],
+    };
+  }
+
+  /**
+   * Returns the report from the most recent sync cycle.
+   */
+  getLastSyncReport(): NPCSyncReport {
+    return {
+      ...this.lastSyncReport,
+      blockedQuotes: [...this.lastSyncReport.blockedQuotes],
+      failedQuotes: [...this.lastSyncReport.failedQuotes],
     };
   }
 
@@ -172,6 +245,8 @@ export class NPCPlugin implements Plugin<typeof requiredServices> {
         ctx.services.paymentRequestService,
         this.npcClient,
         this.sync.bind(this),
+        this.getStatus.bind(this),
+        this.getLastSyncReport.bind(this),
       ),
     );
     return async () => {
@@ -205,11 +280,11 @@ export class NPCPlugin implements Plugin<typeof requiredServices> {
    *
    * @returns Promise that resolves when the sync completes
    */
-  async sync(): Promise<void> {
+  async sync(): Promise<NPCSyncReport> {
     const isReady = await this.waitUntilReady();
-    if (!isReady) return;
+    if (!isReady) return this.getLastSyncReport();
 
-    await this.requestSync("manual");
+    return this.requestSync("manual");
   }
 
   /**
@@ -354,18 +429,20 @@ export class NPCPlugin implements Plugin<typeof requiredServices> {
     }, this.intervalMs);
   }
 
-  private async requestSync(trigger: SyncTrigger): Promise<void> {
-    if (!this.isReady || this.isShuttingDown) return;
+  private async requestSync(trigger: SyncTrigger): Promise<NPCSyncReport> {
+    if (!this.isReady || this.isShuttingDown) {
+      return this.getLastSyncReport();
+    }
 
     // If already running, mark pending update and return existing promise
     if (this.isRunning) {
       this.hasPendingUpdate = true;
-      return this.runPromise ?? Promise.resolve();
+      return this.runPromise ?? Promise.resolve(this.getLastSyncReport());
     }
 
     this.hasPendingUpdate = true;
     this.startRunner(trigger);
-    return this.runPromise ?? Promise.resolve();
+    return this.runPromise ?? Promise.resolve(this.getLastSyncReport());
   }
 
   private startRunner(trigger: SyncTrigger): void {
@@ -374,10 +451,11 @@ export class NPCPlugin implements Plugin<typeof requiredServices> {
 
     this.isRunning = true;
     this.runPromise = (async () => {
+      let report = this.getLastSyncReport();
       try {
         do {
           this.hasPendingUpdate = false;
-          await this.syncPaidQuotesOnce({
+          report = await this.syncPaidQuotesOnce({
             mintOperationService: ctx.services.mintOperationService,
             mintService: ctx.services.mintService,
             trigger,
@@ -394,6 +472,7 @@ export class NPCPlugin implements Plugin<typeof requiredServices> {
         this.isRunning = false;
         this.runPromise = undefined;
       }
+      return report;
     })();
   }
 
@@ -405,9 +484,10 @@ export class NPCPlugin implements Plugin<typeof requiredServices> {
       typeof requiredServices
     >["services"]["mintService"];
     trigger: SyncTrigger;
-  }): Promise<void> {
+  }): Promise<NPCSyncReport> {
     const { mintOperationService, mintService, trigger } = options;
     const since = await this.sinceStore.get();
+    const emptyReport = this.createSyncReport({ since, newSince: since });
 
     this.logger?.debug?.(formatLogMessage("Starting sync", { since, trigger }));
 
@@ -415,7 +495,8 @@ export class NPCPlugin implements Plugin<typeof requiredServices> {
 
     if (!rawQuotes || rawQuotes.length === 0) {
       this.logger?.debug?.("No new quotes");
-      return;
+      this.lastSyncReport = emptyReport;
+      return this.getLastSyncReport();
     }
 
     // Validate and filter quotes
@@ -458,7 +539,8 @@ export class NPCPlugin implements Plugin<typeof requiredServices> {
 
     if (quotes.length === 0) {
       this.logger?.debug?.("No valid quotes after filtering");
-      return;
+      this.lastSyncReport = emptyReport;
+      return this.getLastSyncReport();
     }
 
     quotes.sort((a, b) => {
@@ -495,24 +577,43 @@ export class NPCPlugin implements Plugin<typeof requiredServices> {
           request: quote.request ?? "",
         }));
 
+        let mintAllowed = false;
+        let mintPrepareError: string | undefined;
         try {
-          await mintService.addMintByUrl(mintUrl, { trusted: true });
+          mintAllowed = await this.prepareMintForQuoteImport(
+            mintService,
+            mintUrl,
+          );
         } catch (err) {
+          mintPrepareError = String(err);
           this.logger?.error?.(
-            formatLogMessage("Failed to add trusted mint for quotes", {
-              err: String(err),
+            formatLogMessage("Failed to prepare mint for quotes", {
+              err: mintPrepareError,
               mintUrl,
               quoteCount: list.length,
+              policyMode: this.quoteMintPolicy.mode,
             }),
           );
+        }
+
+        if (!mintAllowed) {
           for (const quote of list) {
             results.push({
               mintUrl,
               quoteId: quote.quoteId,
               paidAt: quote.paidAt,
-              status: "failed",
+              status: mintPrepareError ? "failed" : "blocked",
+              error: mintPrepareError,
             });
           }
+          this.logger?.warn?.(
+            formatLogMessage("Skipped quotes before import", {
+              mintUrl,
+              quoteCount: list.length,
+              policyMode: this.quoteMintPolicy.mode,
+              reason: mintPrepareError ? "mint-prepare-failed" : "blocked",
+            }),
+          );
           return results;
         }
 
@@ -559,6 +660,7 @@ export class NPCPlugin implements Plugin<typeof requiredServices> {
               quoteId: transformedQuote.quoteId,
               paidAt: transformedQuote.paidAt,
               status: "failed",
+              error: String(err),
             });
             this.logger?.error?.(
               formatLogMessage("Failed to import quote", {
@@ -580,6 +682,8 @@ export class NPCPlugin implements Plugin<typeof requiredServices> {
               .length,
             failed: results.filter((result) => result.status === "failed")
               .length,
+            blocked: results.filter((result) => result.status === "blocked")
+              .length,
           }),
         );
 
@@ -588,8 +692,11 @@ export class NPCPlugin implements Plugin<typeof requiredServices> {
     );
 
     const quoteResults = mintResults.flat();
-    const failedPaidAt = quoteResults
-      .filter((result) => result.status === "failed")
+    const unresolvedPaidAt = quoteResults
+      .filter(
+        (result) =>
+          result.status === "failed" || result.status === "blocked",
+      )
       .reduce<number | undefined>((min, result) => {
         if (min === undefined) {
           return result.paidAt;
@@ -599,7 +706,7 @@ export class NPCPlugin implements Plugin<typeof requiredServices> {
 
     let safeSince = since;
     for (const result of quoteResults) {
-      if (failedPaidAt !== undefined && result.paidAt >= failedPaidAt) {
+      if (unresolvedPaidAt !== undefined && result.paidAt >= unresolvedPaidAt) {
         continue;
       }
       safeSince = Math.max(safeSince, result.paidAt);
@@ -625,17 +732,119 @@ export class NPCPlugin implements Plugin<typeof requiredServices> {
     const failedCount = quoteResults.filter(
       (result) => result.status === "failed",
     ).length;
+    const blockedQuotes = quoteResults
+      .filter((result) => result.status === "blocked")
+      .map((result) => ({
+        mintUrl: result.mintUrl,
+        quoteId: result.quoteId,
+        paidAt: result.paidAt,
+      }));
+    const failedQuotes = quoteResults
+      .filter((result) => result.status === "failed")
+      .map((result) => ({
+        mintUrl: result.mintUrl,
+        quoteId: result.quoteId,
+        paidAt: result.paidAt,
+        error: result.error ?? "Unknown error",
+      }));
 
-    if (failedCount > 0) {
+    this.lastSyncReport = this.createSyncReport({
+      since,
+      newSince: safeSince,
+      importedCount,
+      skippedCount,
+      failedCount,
+      blockedQuotes,
+      failedQuotes,
+    });
+
+    if (failedCount > 0 || blockedQuotes.length > 0) {
       this.logger?.warn?.(
-        formatLogMessage("Sync completed with quote failures", {
+        formatLogMessage("Sync completed with unresolved quotes", {
           trigger,
           imported: importedCount,
           skipped: skippedCount,
           failed: failedCount,
+          blocked: blockedQuotes.length,
+          unresolvedWatermark: unresolvedPaidAt,
           safeSince,
         }),
       );
     }
+
+    return this.getLastSyncReport();
+  }
+
+  private createSyncReport(options: {
+    since: number;
+    newSince: number;
+    importedCount?: number;
+    skippedCount?: number;
+    failedCount?: number;
+    blockedQuotes?: NPCBlockedQuote[];
+    failedQuotes?: NPCFailedQuote[];
+  }): NPCSyncReport {
+    return {
+      since: options.since,
+      newSince: options.newSince,
+      importedCount: options.importedCount ?? 0,
+      skippedCount: options.skippedCount ?? 0,
+      failedCount: options.failedCount ?? 0,
+      blockedQuotes: options.blockedQuotes ?? [],
+      failedQuotes: options.failedQuotes ?? [],
+    };
+  }
+
+  private async prepareMintForQuoteImport(
+    mintService: PluginContext<
+      typeof requiredServices
+    >["services"]["mintService"],
+    mintUrl: string,
+  ): Promise<boolean> {
+    switch (this.quoteMintPolicy.mode) {
+      case "trusted-only":
+        return this.isTrustedMint(mintService, mintUrl);
+      case "allow-list":
+        if (!this.quoteMintPolicy.mintUrls.includes(mintUrl)) {
+          return false;
+        }
+        await this.cacheMintWithoutTrusting(mintService, mintUrl);
+        return true;
+      case "auto-trust":
+        await mintService.addMintByUrl(mintUrl, { trusted: true });
+        return true;
+    }
+  }
+
+  private async isTrustedMint(
+    mintService: PluginContext<
+      typeof requiredServices
+    >["services"]["mintService"],
+    mintUrl: string,
+  ): Promise<boolean> {
+    if (typeof mintService.isTrustedMint !== "function") {
+      return false;
+    }
+
+    try {
+      return await mintService.isTrustedMint(mintUrl);
+    } catch (err) {
+      this.logger?.warn?.(
+        formatLogMessage("Unable to determine mint trust", {
+          err: String(err),
+          mintUrl,
+        }),
+      );
+      return false;
+    }
+  }
+
+  private async cacheMintWithoutTrusting(
+    mintService: PluginContext<
+      typeof requiredServices
+    >["services"]["mintService"],
+    mintUrl: string,
+  ): Promise<void> {
+    await mintService.addMintByUrl(mintUrl);
   }
 }

--- a/src/plugins/NPCPlugin.ts
+++ b/src/plugins/NPCPlugin.ts
@@ -1,4 +1,9 @@
-import type { Logger, Plugin, PluginContext } from "coco-cashu-core";
+import {
+  normalizeMintUrl,
+  type Logger,
+  type Plugin,
+  type PluginContext,
+} from "coco-cashu-core";
 import { JWTAuthProvider, NPCClient } from "npubcash-sdk";
 import type { SinceStore } from "../sync/sinceStore";
 import { MemorySinceStore } from "../sync/sinceStore";
@@ -805,7 +810,7 @@ export class NPCPlugin implements Plugin<typeof requiredServices> {
       case "trusted-only":
         return this.isTrustedMint(mintService, mintUrl);
       case "allow-list":
-        if (!this.quoteMintPolicy.mintUrls.includes(mintUrl)) {
+        if (!this.isAllowListedMint(mintUrl)) {
           return false;
         }
         await this.cacheMintWithoutTrusting(mintService, mintUrl);
@@ -814,6 +819,16 @@ export class NPCPlugin implements Plugin<typeof requiredServices> {
         await mintService.addMintByUrl(mintUrl, { trusted: true });
         return true;
     }
+  }
+
+  private isAllowListedMint(mintUrl: string): boolean {
+    const normalizedMintUrl = normalizeMintUrl(mintUrl);
+    return this.quoteMintPolicy.mode === "allow-list"
+      ? this.quoteMintPolicy.mintUrls.some(
+          (allowedMintUrl) =>
+            normalizeMintUrl(allowedMintUrl) === normalizedMintUrl,
+        )
+      : false;
   }
 
   private async isTrustedMint(

--- a/tests/NPCOnDemandPlugin.test.ts
+++ b/tests/NPCOnDemandPlugin.test.ts
@@ -10,7 +10,9 @@ describe("NPCPlugin (manual)", () => {
       sinceStore,
     });
 
-    const { calls, ctx } = createMockContext();
+    const { calls, ctx } = createMockContext({
+      trustedMintUrls: ["https://mint.a"],
+    });
     plugin.onInit(ctx as unknown as Parameters<typeof plugin.onInit>[0]);
     plugin.onReady();
 
@@ -22,7 +24,7 @@ describe("NPCPlugin (manual)", () => {
 
     await plugin.sync();
 
-    expect(calls.addMintByUrl).toEqual(["https://mint.a"]);
+    expect(calls.addMintByUrl).toEqual([]);
     expect(calls.importQuote.length).toBe(1);
     expect(await sinceStore.get()).toBe(10);
   });

--- a/tests/NPCPlugin.test.ts
+++ b/tests/NPCPlugin.test.ts
@@ -11,7 +11,9 @@ describe("NPCPlugin (interval)", () => {
       syncIntervalMs: 1000,
     });
 
-    const { calls, ctx } = createMockContext();
+    const { calls, ctx } = createMockContext({
+      trustedMintUrls: ["https://mint.a"],
+    });
     const cleanup = plugin.onInit(ctx as unknown as Parameters<typeof plugin.onInit>[0]);
 
     // Replace internal npc client with stub
@@ -35,7 +37,7 @@ describe("NPCPlugin (interval)", () => {
         await pluginInternal.runPromise;
       }
 
-      expect(calls.addMintByUrl).toEqual(["https://mint.a"]);
+      expect(calls.addMintByUrl).toEqual([]);
       expect(calls.importQuote.length).toBe(1);
       expect(await sinceStore.get()).toBe(10);
 

--- a/tests/PluginApi.test.ts
+++ b/tests/PluginApi.test.ts
@@ -12,7 +12,32 @@ describe("PluginApi", () => {
       {} as never,
       async () => {
         synced = true;
+        return {
+          since: 0,
+          newSince: 0,
+          importedCount: 0,
+          skippedCount: 0,
+          failedCount: 0,
+          blockedQuotes: [],
+          failedQuotes: [],
+        };
       },
+      () => ({
+        isInitialized: true,
+        isReady: true,
+        isSyncing: false,
+        isWebSocketConnected: false,
+        blockedQuotes: [],
+      }),
+      () => ({
+        since: 0,
+        newSince: 0,
+        importedCount: 0,
+        skippedCount: 0,
+        failedCount: 0,
+        blockedQuotes: [],
+        failedQuotes: [],
+      }),
     );
 
     await api.sync();
@@ -26,7 +51,9 @@ describe("PluginApi", () => {
       sinceStore,
     });
 
-    const { calls, services } = createMockServices();
+    const { calls, services } = createMockServices({
+      trustedMintUrls: ["https://mint.a"],
+    });
     let extension: PluginApi | undefined;
     const ctx = {
       services,
@@ -55,7 +82,7 @@ describe("PluginApi", () => {
 
     await extension?.sync();
 
-    expect(calls.addMintByUrl).toEqual(["https://mint.a"]);
+    expect(calls.addMintByUrl).toEqual([]);
     expect(calls.importQuote.length).toBe(1);
     expect(await sinceStore.get()).toBe(10);
   });
@@ -98,5 +125,60 @@ describe("PluginApi", () => {
 
     expect(called).toBe(true);
     expect(settled).toBe(true);
+  });
+
+  it("delegates NPC account settings updates to the SDK client", async () => {
+    const calls = {
+      setMintUrl: [] as string[],
+      setLock: [] as boolean[],
+    };
+    const api = new PluginApi(
+      {} as never,
+      {
+        settings: {
+          setMintUrl: async (mintUrl: string) => {
+            calls.setMintUrl.push(mintUrl);
+            return { user: { mintUrl } };
+          },
+          setLock: async (lock: boolean) => {
+            calls.setLock.push(lock);
+            return { user: { lock } };
+          },
+        },
+      } as never,
+      async () => ({
+        since: 0,
+        newSince: 0,
+        importedCount: 0,
+        skippedCount: 0,
+        failedCount: 0,
+        blockedQuotes: [],
+        failedQuotes: [],
+      }),
+      () => ({
+        isInitialized: true,
+        isReady: true,
+        isSyncing: false,
+        isWebSocketConnected: false,
+        blockedQuotes: [],
+      }),
+      () => ({
+        since: 0,
+        newSince: 0,
+        importedCount: 0,
+        skippedCount: 0,
+        failedCount: 0,
+        blockedQuotes: [],
+        failedQuotes: [],
+      }),
+    );
+
+    const mintResult = await api.setMintUrl("https://mint.example.com");
+    const lockResult = await api.setLockQuotes(true);
+
+    expect(calls.setMintUrl).toEqual(["https://mint.example.com"]);
+    expect(calls.setLock).toEqual([true]);
+    expect(mintResult).toEqual({ user: { mintUrl: "https://mint.example.com" } });
+    expect(lockResult).toEqual({ user: { lock: true } });
   });
 });

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -12,16 +12,33 @@ export function createMockSigner(): Signer {
 /**
  * Creates mock services for testing
  */
-export function createMockServices() {
+export function createMockServices(options?: {
+  trustedMintUrls?: readonly string[];
+}) {
+  const trustedMintUrls = new Set(options?.trustedMintUrls ?? []);
   const calls = {
     addMintByUrl: [] as string[],
+    addMintByUrlOptions: [] as { url: string; trusted?: boolean }[],
+    ensureUpdatedMint: [] as string[],
+    isTrustedMint: [] as string[],
     importQuote: [] as { url: string; quote: unknown }[],
   };
 
   const services = {
     mintService: {
-      addMintByUrl: async (url: string) => {
+      addMintByUrl: async (url: string, addOptions?: { trusted?: boolean }) => {
         calls.addMintByUrl.push(url);
+        calls.addMintByUrlOptions.push({ url, trusted: addOptions?.trusted });
+        if (addOptions?.trusted) {
+          trustedMintUrls.add(url);
+        }
+      },
+      ensureUpdatedMint: async (url: string) => {
+        calls.ensureUpdatedMint.push(url);
+      },
+      isTrustedMint: async (url: string) => {
+        calls.isTrustedMint.push(url);
+        return trustedMintUrls.has(url);
       },
     },
     mintOperationService: {
@@ -39,8 +56,10 @@ export function createMockServices() {
 /**
  * Creates a mock plugin context
  */
-export function createMockContext() {
-  const { calls, services } = createMockServices();
+export function createMockContext(options?: {
+  trustedMintUrls?: readonly string[];
+}) {
+  const { calls, services } = createMockServices(options);
   return {
     calls,
     ctx: {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -69,6 +69,7 @@ describe("type exports (compile-time check)", () => {
       isReady: true,
       isSyncing: false,
       isWebSocketConnected: false,
+      blockedQuotes: [],
     };
     expect(status.isReady).toBe(true);
   });

--- a/tests/syncPaidQuotes.test.ts
+++ b/tests/syncPaidQuotes.test.ts
@@ -31,6 +31,8 @@ describe("NPCPlugin sync mapping", () => {
           addMintByUrl: async (url: string) => {
             calls.addMintByUrl.push(url);
           },
+          isTrustedMint: async (url: string) =>
+            url === "https://mint.a" || url === "https://mint.b",
         },
         mintOperationService: {
           getOperationByQuote: async () => undefined,
@@ -52,11 +54,7 @@ describe("NPCPlugin sync mapping", () => {
 
     await plugin.sync();
 
-    // Both mints should be added (order may vary due to Promise.all)
-    expect(calls.addMintByUrl.sort()).toEqual([
-      "https://mint.a",
-      "https://mint.b",
-    ]);
+    expect(calls.addMintByUrl).toEqual([]);
 
     const groupA = calls.importQuote.filter((g) => g.url === "https://mint.a");
     const groupB = calls.importQuote.filter((g) => g.url === "https://mint.b");
@@ -116,6 +114,209 @@ describe("NPCPlugin sync mapping", () => {
     expect(setCalled).toBe(false);
   });
 
+  it("blocks unknown quote mints by default and preserves the watermark", async () => {
+    const calls = {
+      addMintByUrl: [] as string[],
+      importQuote: [] as { url: string; quote: unknown }[],
+      setSince: [] as number[],
+    };
+    const sinceStore = {
+      get: async () => 0,
+      set: async (since: number) => {
+        calls.setSince.push(since);
+      },
+    };
+
+    const plugin = new NPCPlugin(
+      "https://npc.example.com",
+      createMockSigner(),
+      {
+        sinceStore,
+      },
+    );
+
+    const ctx = {
+      services: {
+        mintService: {
+          addMintByUrl: async (url: string) => {
+            calls.addMintByUrl.push(url);
+          },
+          isTrustedMint: async () => false,
+        },
+        mintOperationService: {
+          getOperationByQuote: async () => undefined,
+          importQuote: async (url: string, quote: unknown) => {
+            calls.importQuote.push({ url, quote });
+          },
+        },
+        paymentRequestService: {},
+      },
+      registerExtension: () => {},
+    };
+
+    plugin.onInit(ctx as Parameters<typeof plugin.onInit>[0]);
+    plugin.onReady();
+
+    (plugin as unknown as { npcClient: unknown }).npcClient = {
+      getQuotesSince: async () => [
+        {
+          mintUrl: "https://mint.unknown",
+          quoteId: "blocked",
+          paidAt: 100,
+          expiresAt: 200,
+          amount: 50,
+        },
+      ],
+    };
+
+    const report = await plugin.sync();
+
+    expect(calls.addMintByUrl).toEqual([]);
+    expect(calls.importQuote).toEqual([]);
+    expect(calls.setSince).toEqual([]);
+    expect(report.blockedQuotes).toEqual([
+      {
+        mintUrl: "https://mint.unknown",
+        quoteId: "blocked",
+        paidAt: 100,
+      },
+    ]);
+    expect(plugin.getStatus().blockedQuotes).toEqual(report.blockedQuotes);
+  });
+
+  it("imports allow-listed quote mints without trusting them", async () => {
+    const calls = {
+      addMintByUrl: [] as { url: string; trusted?: boolean }[],
+      importQuote: [] as { url: string; quote: unknown }[],
+      setSince: [] as number[],
+    };
+    const sinceStore = {
+      get: async () => 0,
+      set: async (since: number) => {
+        calls.setSince.push(since);
+      },
+    };
+
+    const plugin = new NPCPlugin(
+      "https://npc.example.com",
+      createMockSigner(),
+      {
+        sinceStore,
+        quoteMintPolicy: {
+          mode: "allow-list",
+          mintUrls: ["https://mint.allowed"],
+        },
+      },
+    );
+
+    const ctx = {
+      services: {
+        mintService: {
+          addMintByUrl: async (url: string, options?: { trusted?: boolean }) => {
+            calls.addMintByUrl.push({ url, trusted: options?.trusted });
+          },
+          isTrustedMint: async () => false,
+        },
+        mintOperationService: {
+          getOperationByQuote: async () => undefined,
+          importQuote: async (url: string, quote: unknown) => {
+            calls.importQuote.push({ url, quote });
+          },
+        },
+        paymentRequestService: {},
+      },
+      registerExtension: () => {},
+    };
+
+    plugin.onInit(ctx as Parameters<typeof plugin.onInit>[0]);
+    plugin.onReady();
+
+    (plugin as unknown as { npcClient: unknown }).npcClient = {
+      getQuotesSince: async () => [
+        {
+          mintUrl: "https://mint.allowed",
+          quoteId: "allowed",
+          paidAt: 100,
+          expiresAt: 200,
+          amount: 50,
+        },
+      ],
+    };
+
+    const report = await plugin.sync();
+
+    expect(calls.addMintByUrl).toEqual([
+      { url: "https://mint.allowed", trusted: undefined },
+    ]);
+    expect(calls.importQuote.length).toBe(1);
+    expect(calls.setSince).toEqual([100]);
+    expect(report.blockedQuotes).toEqual([]);
+  });
+
+  it("preserves legacy auto-trust behavior when explicitly configured", async () => {
+    const calls = {
+      addMintByUrl: [] as { url: string; trusted?: boolean }[],
+      importQuote: [] as { url: string; quote: unknown }[],
+      setSince: [] as number[],
+    };
+    const sinceStore = {
+      get: async () => 0,
+      set: async (since: number) => {
+        calls.setSince.push(since);
+      },
+    };
+
+    const plugin = new NPCPlugin(
+      "https://npc.example.com",
+      createMockSigner(),
+      {
+        sinceStore,
+        quoteMintPolicy: { mode: "auto-trust" },
+      },
+    );
+
+    const ctx = {
+      services: {
+        mintService: {
+          addMintByUrl: async (url: string, options?: { trusted?: boolean }) => {
+            calls.addMintByUrl.push({ url, trusted: options?.trusted });
+          },
+        },
+        mintOperationService: {
+          getOperationByQuote: async () => undefined,
+          importQuote: async (url: string, quote: unknown) => {
+            calls.importQuote.push({ url, quote });
+          },
+        },
+        paymentRequestService: {},
+      },
+      registerExtension: () => {},
+    };
+
+    plugin.onInit(ctx as Parameters<typeof plugin.onInit>[0]);
+    plugin.onReady();
+
+    (plugin as unknown as { npcClient: unknown }).npcClient = {
+      getQuotesSince: async () => [
+        {
+          mintUrl: "https://mint.legacy",
+          quoteId: "legacy",
+          paidAt: 100,
+          expiresAt: 200,
+          amount: 50,
+        },
+      ],
+    };
+
+    await plugin.sync();
+
+    expect(calls.addMintByUrl).toEqual([
+      { url: "https://mint.legacy", trusted: true },
+    ]);
+    expect(calls.importQuote.length).toBe(1);
+    expect(calls.setSince).toEqual([100]);
+  });
+
   it("skips invalid quotes and logs warning", async () => {
     const warnings: unknown[] = [];
     const sinceStore = {
@@ -145,7 +346,10 @@ describe("NPCPlugin sync mapping", () => {
 
     const ctx = {
       services: {
-        mintService: { addMintByUrl: async () => {} },
+        mintService: {
+          addMintByUrl: async () => {},
+          isTrustedMint: async (url: string) => url === "https://mint.a",
+        },
         mintOperationService: {
           getOperationByQuote: async () => undefined,
           importQuote: async (url: string, quote: unknown) => {
@@ -231,6 +435,8 @@ describe("NPCPlugin sync mapping", () => {
       services: {
         mintService: {
           addMintByUrl: async () => {},
+          isTrustedMint: async (url: string) =>
+            url === "https://mint.a" || url === "https://mint.b",
         },
         mintOperationService: {
           getOperationByQuote: async (_url: string, quoteId: string) => {
@@ -303,7 +509,7 @@ describe("NPCPlugin sync mapping", () => {
     expect(calls.importAttempt.toSorted()).toEqual(["q1", "q2", "q3"]);
     expect(calls.lookupQuote.toSorted()).toEqual(["q1", "q2", "q3"]);
     expect(calls.setSince).toEqual([110]);
-    expect(warnings.some((message) => message.includes("Sync completed with quote failures"))).toBe(true);
+    expect(warnings.some((message) => message.includes("Sync completed with unresolved quotes"))).toBe(true);
     expect(errors.some((message) => message.includes("Failed to import quote"))).toBe(true);
 
     calls.lookupQuote = [];
@@ -354,6 +560,7 @@ describe("NPCPlugin sync mapping", () => {
       services: {
         mintService: {
           addMintByUrl: async () => {},
+          isTrustedMint: async (url: string) => url === "https://mint.a",
         },
         mintOperationService: {
           getOperationByQuote: async (_url: string, quoteId: string) =>

--- a/tests/syncPaidQuotes.test.ts
+++ b/tests/syncPaidQuotes.test.ts
@@ -253,6 +253,73 @@ describe("NPCPlugin sync mapping", () => {
     expect(report.blockedQuotes).toEqual([]);
   });
 
+  it("normalizes allow-listed quote mint URLs before comparing", async () => {
+    const calls = {
+      addMintByUrl: [] as string[],
+      importQuote: [] as { url: string; quote: unknown }[],
+      setSince: [] as number[],
+    };
+    const sinceStore = {
+      get: async () => 0,
+      set: async (since: number) => {
+        calls.setSince.push(since);
+      },
+    };
+
+    const plugin = new NPCPlugin(
+      "https://npc.example.com",
+      createMockSigner(),
+      {
+        sinceStore,
+        quoteMintPolicy: {
+          mode: "allow-list",
+          mintUrls: ["https://MINT.allowed:443/"],
+        },
+      },
+    );
+
+    const ctx = {
+      services: {
+        mintService: {
+          addMintByUrl: async (url: string) => {
+            calls.addMintByUrl.push(url);
+          },
+          isTrustedMint: async () => false,
+        },
+        mintOperationService: {
+          getOperationByQuote: async () => undefined,
+          importQuote: async (url: string, quote: unknown) => {
+            calls.importQuote.push({ url, quote });
+          },
+        },
+        paymentRequestService: {},
+      },
+      registerExtension: () => {},
+    };
+
+    plugin.onInit(ctx as Parameters<typeof plugin.onInit>[0]);
+    plugin.onReady();
+
+    (plugin as unknown as { npcClient: unknown }).npcClient = {
+      getQuotesSince: async () => [
+        {
+          mintUrl: "https://mint.allowed",
+          quoteId: "allowed",
+          paidAt: 100,
+          expiresAt: 200,
+          amount: 50,
+        },
+      ],
+    };
+
+    const report = await plugin.sync();
+
+    expect(calls.addMintByUrl).toEqual(["https://mint.allowed"]);
+    expect(calls.importQuote.length).toBe(1);
+    expect(calls.setSince).toEqual([100]);
+    expect(report.blockedQuotes).toEqual([]);
+  });
+
   it("preserves legacy auto-trust behavior when explicitly configured", async () => {
     const calls = {
       addMintByUrl: [] as { url: string; trusted?: boolean }[],


### PR DESCRIPTION
## Summary
- Refines the NPC plugin trust flow so mint handling and quote syncing stay aligned with the host API
- Updates `PluginApi` and plugin lifecycle behavior to match the current `NPCPlugin` implementation
- Expands test coverage across plugin API, sync paths, and export wiring
- Refreshes README examples to reflect the supported surface area

## Testing
- Added and updated unit coverage for `NPCPlugin`, `PluginApi`, sync paid-quote handling, and package exports
- Not run (not requested)